### PR TITLE
[RD-9] feat(internals): Add coin flip option support;

### DIFF
--- a/roll-dice/internal/options/options_test.go
+++ b/roll-dice/internal/options/options_test.go
@@ -40,8 +40,7 @@ func TestDisplay(t *testing.T) {
 
 func TestProcessInput(t *testing.T) {
 	// Tests input processing for error and passing values
-
-	options := setUp()
+	// Ignoring stdout helps with extra lines added to processInput
 	origStdout, ignoreOut := testing_utils.IgnoreStdout()
 
 	expected := ""
@@ -50,13 +49,13 @@ func TestProcessInput(t *testing.T) {
 	// Err : non-numeric
 	stdin.Write([]byte("invalid"))
 	expected = "strconv.Atoi: parsing \"invalid\": invalid syntax"
-	_, err := options.processInput(&stdin)
+	_, err := processInput(&stdin)
 	testing_utils.AssertEQ(t, expected, err.Error())
 	stdin.Reset()
 
 	// Pass : unsupported
 	stdin.Write([]byte("-1"))
-	input, err := options.processInput(&stdin)
+	input, err := processInput(&stdin)
 	testing_utils.AssertNIL(t, err)
 	testing_utils.AssertEQi(t, -1, input)
 	stdin.Reset()
@@ -75,7 +74,7 @@ func TestMenuOptions(t *testing.T) {
 
 	/// - -1) Unsupported Option
 	err := options.runOption(-1)
-	expected = "unsupported option"
+	expected = ErrUnsupported
 	testing_utils.AssertEQ(t, expected, err.Error())
 
 	/// - 0) Exit
@@ -85,12 +84,12 @@ func TestMenuOptions(t *testing.T) {
 
 	/// - 1) Flip Coins
 	err = options.runOption(flip_coins)
-	expected = "not yet implemented"
+	expected = SyntaxErrExpectedInt
 	testing_utils.AssertEQ(t, expected, err.Error())
 
 	/// - 2) Roll Dice
 	err = options.runOption(roll_dice)
-	expected = "not yet implemented"
+	expected = ErrNotImplemented
 	testing_utils.AssertEQ(t, expected, err.Error())
 
 	testing_utils.IgnoreStdoutClose(origStdout, ignoreOut)

--- a/roll-dice/internal/probgen/coinflip.go
+++ b/roll-dice/internal/probgen/coinflip.go
@@ -1,0 +1,47 @@
+/*
+coinflip.go
+
+CoinFlip is a ProbEventType which
+describes coin flips
+*/
+package probgen
+
+import "fmt"
+
+const Heads = "Heads"
+const Tails = "Tails"
+
+type CoinFlip struct {
+	NumEvents int // number of coin flips
+}
+
+func (coinFlip CoinFlip) Execute() error {
+	res, err := GenerateProbabilisticEvent(
+		coinFlip.NumEvents,
+		[]string{
+			Heads,
+			Tails})
+
+	if err == nil {
+		coinFlip.display(res)
+	}
+
+	return err
+}
+
+// Print the coin flip results. Example:
+//
+// NumEvents: 123435
+//
+// (H) :  49.882126% : 61572
+//
+// (T) :  50.117874% : 61863
+//
+//	Params
+//		res map[string]int : results of coin flips
+func (coinFlip CoinFlip) display(res map[string]int) {
+	fmt.Printf(
+		"(H) : %10f%% : %d\n(T) : %10f%% : %d\n",
+		Percent(res[Heads], coinFlip.NumEvents), res[Heads],
+		Percent(res[Tails], coinFlip.NumEvents), res[Tails])
+}

--- a/roll-dice/internal/probgen/probgen.go
+++ b/roll-dice/internal/probgen/probgen.go
@@ -13,7 +13,7 @@ import (
 
 /// Constants
 
-const ErrInvalidEvents = "invalid number of events: must be a positive integer"
+const ErrInvalidEvents = "invalid number of events: must be more than one event"
 const ErrInvalidPossibilities = "invalid number of possibilities: must have at least one possible outcome"
 
 type ProbEvent struct {
@@ -108,8 +108,7 @@ func randNumGen(num_outcomes int) int {
 //
 //		returns : {"heads":2, "tails":1}
 func GenerateProbabilisticEvent(events int, possibilities []string) (map[string]int, error) {
-	if events < 0 {
-		// Can not have negative events
+	if events < 1 {
 		return nil, errors.New(ErrInvalidEvents)
 	} else if len(possibilities) < 1 {
 		// Must have at least one possible outcome
@@ -118,4 +117,19 @@ func GenerateProbabilisticEvent(events int, possibilities []string) (map[string]
 
 	probEvent := ProbEvent{numEvents: events, outcomes: possibilities, prng: randNumGen}
 	return probEvent.computeProbability(), nil
+}
+
+// ProbEvent interface for use in options
+type ProbEventType interface {
+	Execute()               // Compute and display result
+	display(map[string]int) // Display results
+}
+
+// Utility to compute the percent: numerator / denominator
+//
+//	Params
+//		numerator int   : divided by denominator
+//		denominator int : divides numerator
+func Percent(numerator int, denominator int) float32 {
+	return float32(numerator) * 100 / float32(denominator)
 }


### PR DESCRIPTION
coinflip.go
* support for flipping coins

probgen_test.go
* added tests for display for `CoinFlip`

options.go
* modified `processInput `so it can be tested with unit tests easier
* `displayOptions `now called separately from `processInput`