### PR TITLE
[RD-11] refactor(internal): Refocus checks to validate;

### DIFF
--- a/roll-dice/internal/options/options.go
+++ b/roll-dice/internal/options/options.go
@@ -51,7 +51,8 @@ func (options Options) displayOptions() {
 
 // Register all Options
 //
-//	opts[optNum] = Opt{name: _, optNum: _}
+//	Example:
+//		opts[optNum] = Opt{name: _, optNum: _}
 func (options *Options) registerOptions() {
 	options.opts = make(map[int]Opt)
 	options.opts[exit] = OptExit{name: "Exit", optNum: exit}
@@ -90,6 +91,8 @@ type OptExit struct {
 }
 
 func (optExit OptExit) process() error {
+	// Simply exit gracefully
+
 	fmt.Print("Exiting now ")
 	for i := 0; i < 3; i++ {
 		time.Sleep(500 * time.Millisecond)
@@ -116,15 +119,15 @@ type OptFlipCoins struct {
 }
 
 func (optFlipCoins OptFlipCoins) process() error {
-	// Only need the number of coin flips, the possible
-	// outcomes are already known
-	fmt.Print("Please enter the number of coin flips\n")
+	// Prompt user for the number of coin flips they want to do
+
+	fmt.Print("Please enter the number of coin flips:\n")
 	input, err := processInput(os.Stdin)
 	if err != nil {
 		return errors.New(SyntaxErrExpectedInt)
 	}
 
-	coinFlip := probgen.CoinFlip{NumEvents: input}
+	coinFlip := probgen.NewCoinFlip(input)
 
 	return probgen.ValidateAndExecute(coinFlip)
 }
@@ -145,21 +148,21 @@ type OptRollDice struct {
 }
 
 func (optRollDice OptRollDice) process() error {
-	// Need the number of sides on the dice
+	// Prompt the user for the number of sides on the dice
 	fmt.Printf("Please select the number of dice sides %s:\n", probgen.ValidDiceTypes)
 	sides, err := processInput(os.Stdin)
 	if err != nil {
 		return errors.New(SyntaxErrExpectedInt)
 	}
 
-	// Need the number of rolls for the dice
-	fmt.Print("Please enter the number of dice rolls\n")
+	// Prompt the user for the number of rolls for the dice
+	fmt.Print("Please enter the number of dice rolls:\n")
 	rolls, err := processInput(os.Stdin)
 	if err != nil {
 		return errors.New(SyntaxErrExpectedInt)
 	}
 
-	diceRoll := probgen.DiceRoll{NumEvents: rolls, NumSides: sides}
+	diceRoll := probgen.NewDiceRoll(rolls, sides)
 
 	return probgen.ValidateAndExecute(diceRoll)
 }
@@ -191,15 +194,15 @@ func processInput(stdin io.Reader) (int, error) {
 // Main driving function. Will continue to prompt user for input
 // until failure or user asks to exit
 func Menu() {
-	user_exit := false
+	input, err := -1, error(nil)
 
 	menu_options := Options{}
 	menu_options.registerOptions()
 
-	for !user_exit {
+	for input != exit {
 		// User input for menu option parsed
 		menu_options.displayOptions()
-		input, err := processInput(os.Stdin)
+		input, err = processInput(os.Stdin)
 		if err != nil {
 			fmt.Print(SyntaxErrExpectedInt)
 			continue
@@ -210,9 +213,5 @@ func Menu() {
 		if err != nil {
 			fmt.Print(err)
 		}
-
-		// End of iteration
-		// When exit is selected, stop here
-		user_exit = input == exit
 	}
 }

--- a/roll-dice/internal/probgen/coinflip.go
+++ b/roll-dice/internal/probgen/coinflip.go
@@ -8,11 +8,26 @@ package probgen
 
 import "fmt"
 
-const Heads = "Heads"
-const Tails = "Tails"
+// Potential values
+const (
+	Heads = "Heads"
+	Tails = "Tails"
+)
 
 type CoinFlip struct {
-	NumEvents int // number of coin flips
+	numEvents int // number of coin flips
+}
+
+// Initialize private fields
+//
+//	Params
+//		nEvents int : number of CoinFlip events
+//	Returns
+//		*CoinFlip : new CoinFlip object
+func NewCoinFlip(nEvents int) *CoinFlip {
+	return &CoinFlip{
+		numEvents: nEvents,
+	}
 }
 
 func (coinFlip CoinFlip) validate() (bool, error) {
@@ -22,7 +37,7 @@ func (coinFlip CoinFlip) validate() (bool, error) {
 
 func (coinFlip CoinFlip) execute() error {
 	res, err := GenerateProbabilisticEvent(
-		coinFlip.NumEvents,
+		coinFlip.numEvents,
 		[]string{
 			Heads,
 			Tails})
@@ -36,7 +51,7 @@ func (coinFlip CoinFlip) execute() error {
 
 // Print the coin flip results. Example:
 //
-// NumEvents: 123435
+// numEvents: 123435
 //
 // (H) :  49.882126% : 61572
 //
@@ -47,6 +62,14 @@ func (coinFlip CoinFlip) execute() error {
 func (coinFlip CoinFlip) display(res map[string]int) {
 	fmt.Printf(
 		"(H) : %10f%% : %d\n(T) : %10f%% : %d\n",
-		Percent(res[Heads], coinFlip.NumEvents), res[Heads],
-		Percent(res[Tails], coinFlip.NumEvents), res[Tails])
+		Percent(res[Heads], coinFlip.numEvents), res[Heads],
+		Percent(res[Tails], coinFlip.numEvents), res[Tails])
+}
+
+// Retrieve number of events
+//
+//	Returns
+//		int : number of events
+func (coinFlip CoinFlip) getNumEvents() int {
+	return coinFlip.numEvents
 }

--- a/roll-dice/internal/probgen/diceroll.go
+++ b/roll-dice/internal/probgen/diceroll.go
@@ -12,8 +12,9 @@ import (
 	"strconv"
 )
 
-const ErrInvalidDiceType = "invalid dice type: must be one of " + ValidDiceTypes
+const ErrInvalidDiceType = "invalid number of dice sides: must be one of " + ValidDiceTypes
 
+// Potential dice types
 const (
 	D4  = 4
 	D6  = 6
@@ -22,24 +23,40 @@ const (
 	D20 = 20
 )
 
+// Valid dice types string
 const ValidDiceTypes = "(4, 6, 10, 12, 20)"
 
-var DicePossibleValues = []string{
-	"1", "2", "3", "4",
-	"5", "6",
-	"7", "8", "9", "10",
-	"11", "12",
-	"13", "14", "15", "16", "17", "18", "19", "20",
+// All possible dice values
+var dicePossibleValues = []string{
+	"1", "2", "3", "4", // D4
+	"5", "6", // -> D6
+	"7", "8", "9", "10", // -> D10
+	"11", "12", // -> D12
+	"13", "14", "15", "16", "17", "18", "19", "20", // -> D20
 }
 
 type DiceRoll struct {
-	NumEvents int // number of coin flips
-	NumSides  int // number of sides on dice
+	numEvents int // number of coin flips
+	numSides  int // number of sides on dice
+}
+
+// Initialize private fields
+//
+//	Params
+//		nEvents int : number of DiceRoll events
+//		nSides int  : number of sides to the dice
+//	Returns
+//		*DiceRoll : new DiceRoll object
+func NewDiceRoll(nEvents int, nSides int) *DiceRoll {
+	return &DiceRoll{
+		numEvents: nEvents,
+		numSides:  nSides,
+	}
 }
 
 func (diceRoll DiceRoll) validate() (bool, error) {
 	//  Need to make sure the provided dice type is valid
-	if !validDiceType(diceRoll.NumSides) {
+	if !validDiceType(diceRoll.numSides) {
 		return false, errors.New(ErrInvalidDiceType)
 	}
 
@@ -48,8 +65,8 @@ func (diceRoll DiceRoll) validate() (bool, error) {
 
 func (diceRoll DiceRoll) execute() error {
 	res, err := GenerateProbabilisticEvent(
-		diceRoll.NumEvents,
-		possibleDiceValues(diceRoll.NumSides))
+		diceRoll.numEvents,
+		possibleDiceValues(diceRoll.numSides))
 
 	if err == nil {
 		diceRoll.display(res)
@@ -60,7 +77,7 @@ func (diceRoll DiceRoll) execute() error {
 
 // Print the coin flip results. Example:
 //
-// NumEvents: 123435
+// numEvents: 123435
 //
 // (H) :  49.882126% : 61572
 //
@@ -69,17 +86,32 @@ func (diceRoll DiceRoll) execute() error {
 //	Params
 //		res map[string]int : results of coin flips
 func (diceRoll DiceRoll) display(res map[string]int) {
-	for i := 1; i <= diceRoll.NumSides; i++ {
+	for i := 1; i <= diceRoll.numSides; i++ {
 		i_s := strconv.Itoa(i)
 		fmt.Printf(
 			"%-4s : %10f%% : %d\n",
 			"["+i_s+"]",
-			Percent(res[i_s], diceRoll.NumEvents),
+			Percent(res[i_s], diceRoll.numEvents),
 			res[i_s],
 		)
 	}
 }
 
+// Retrieve number of events
+//
+//	Returns
+//		int : number of events
+func (diceRoll DiceRoll) getNumEvents() int {
+	return diceRoll.numEvents
+}
+
+// Make sure this is a valid dice type
+//
+//	Params
+//		dType int : dice type
+//	Returns
+//		bool : true if dType in {D4, D6, D10, D12, D20}
+//			   false otherwise
 func validDiceType(dType int) bool {
 	switch dType {
 	case D4, D6, D10, D12, D20:
@@ -89,6 +121,19 @@ func validDiceType(dType int) bool {
 	}
 }
 
+// Get all the possible values for the particular type of dice. Do not call
+// without validating first
+//
+//	Params
+//		dType int : dice type
+//	Returns
+//		[]string : slice of valid dice outputs
+//			Ex:
+//				D4  [1, 4]
+//				D6  [1, 6]
+//				D10 [1, 10]
+//				D12 [1, 12]
+//				D20 [1, 20]
 func possibleDiceValues(dType int) []string {
-	return DicePossibleValues[:dType]
+	return dicePossibleValues[:dType]
 }

--- a/roll-dice/internal/probgen/probgen.go
+++ b/roll-dice/internal/probgen/probgen.go
@@ -16,6 +16,7 @@ import (
 const ErrInvalidEvents = "invalid number of events: must be more than one event"
 const ErrInvalidPossibilities = "invalid number of possibilities: must have at least one possible outcome"
 
+// Generic probability event object
 type ProbEvent struct {
 	numEvents int           // Number of probabilistic events
 	outcomes  []string      // Total possible outcomes of events
@@ -108,9 +109,7 @@ func randNumGen(num_outcomes int) int {
 //
 //		returns : {"heads":2, "tails":1}
 func GenerateProbabilisticEvent(events int, possibilities []string) (map[string]int, error) {
-	if events < 1 {
-		return nil, errors.New(ErrInvalidEvents)
-	} else if len(possibilities) < 1 {
+	if len(possibilities) < 1 {
 		// Must have at least one possible outcome
 		return nil, errors.New(ErrInvalidPossibilities)
 	}
@@ -124,15 +123,38 @@ type ProbEventType interface {
 	validate() (bool, error) // Check input is valid
 	execute() error          // Compute and display result
 	display(map[string]int)  // Display results
+	getNumEvents() int       // Retrieve number of events
 }
 
 func ValidateAndExecute(probEventType ProbEventType) error {
-	ok, err := probEventType.validate()
+	// Generic probability event validation
+	ok, err := validate(probEventType)
+	if !ok {
+		return err
+	}
+
+	// Specialized probability event validation
+	ok, err = probEventType.validate()
 	if !ok {
 		return err
 	}
 
 	return probEventType.execute()
+}
+
+// Generally applicable ProbEvent validation
+//
+//	Params
+//		probEventType ProbEventType : probability event to check
+//	Returns
+//		bool  : valid status
+//		error : indicates any errors leading to validation failure
+func validate(probEventType ProbEventType) (bool, error) {
+	if probEventType.getNumEvents() < 1 {
+		return false, errors.New(ErrInvalidEvents)
+	}
+
+	return true, nil
 }
 
 // Utility to compute the percent: numerator / denominator


### PR DESCRIPTION
Keep validation checks to probgen.validate or ProbEventType specific implmentations

Also use private member fields for CoinFlip and DiceRoll. Introduce constructor methods to achieve this