### PR TITLE
[RD-12] refactor(options): Refactor for repeatable options;

### DIFF
--- a/roll-dice/internal/options/options_test.go
+++ b/roll-dice/internal/options/options_test.go
@@ -49,13 +49,13 @@ func TestProcessInput(t *testing.T) {
 	// Err : non-numeric
 	stdin.Write([]byte("invalid"))
 	expected = "strconv.Atoi: parsing \"invalid\": invalid syntax"
-	_, err := processInput(&stdin)
+	_, _, err := processInput(&stdin)
 	testing_utils.AssertEQ(t, expected, err.Error())
 	stdin.Reset()
 
 	// Pass : unsupported
 	stdin.Write([]byte("-1"))
-	input, err := processInput(&stdin)
+	_, input, err := processInput(&stdin)
 	testing_utils.AssertNIL(t, err)
 	testing_utils.AssertEQi(t, -1, input)
 	stdin.Reset()
@@ -73,24 +73,26 @@ func TestMenuOptions(t *testing.T) {
 	expected := ""
 
 	/// - -1) Unsupported Option
-	err := options.runOption(-1)
+	done, err := options.runOption(-1)
 	expected = ErrUnsupported
 	testing_utils.AssertEQ(t, expected, err.Error())
+	testing_utils.AssertEQb(t, false, done)
 
 	/// - 0) Exit
-	err = options.runOption(exit)
+	done, err = options.runOption(exit)
 	expected = "nil"
 	testing_utils.AssertNIL(t, err)
+	testing_utils.AssertEQb(t, true, done)
 
 	/// - 1) Flip Coins
-	err = options.runOption(flip_coins)
-	expected = SyntaxErrExpectedInt
-	testing_utils.AssertEQ(t, expected, err.Error())
+	done, err = options.runOption(flip_coins)
+	testing_utils.AssertNIL(t, err)
+	testing_utils.AssertEQb(t, false, done)
 
 	/// - 2) Roll Dice
-	err = options.runOption(roll_dice)
-	expected = SyntaxErrExpectedInt
-	testing_utils.AssertEQ(t, expected, err.Error())
+	done, err = options.runOption(roll_dice)
+	testing_utils.AssertNIL(t, err)
+	testing_utils.AssertEQb(t, false, done)
 
 	testing_utils.IgnoreStdoutClose(origStdout, ignoreOut)
 }


### PR DESCRIPTION
Instead of reverting back to the main menu after each event, we should re-prompt for the same option until user indicates they are done. If an empty input is provided, this indicates a return to the main menu

### Current Behavior (reprompt menu every iteration)
```
--------------- Welcome ---------------


Please enter the option number

Registered Options:

        0) Exit
        1) Flip Coins
        2) Roll Dice
1

Please enter the number of coin flips
5

(H) :  80.000000% : 4
(T) :  20.000000% : 1


Please enter the option number

Registered Options:

        0) Exit
        1) Flip Coins
        2) Roll Dice
```

### New Behavior (reprompt option, not menu on every iteration)
```
--------------- Welcome ---------------


Please enter the option number

Registered Options:

        0) Exit
        1) Flip Coins
        2) Roll Dice
1

Please enter the number of coin flips
5

(H) :  80.000000% : 4
(T) :  20.000000% : 1

Please enter the number of coin flips
2

(H) :  50.000000% : 1
(T) :  50.000000% : 1
Please enter the option number


Registered Options:

        0) Exit
        1) Flip Coins
        2) Roll Dice
```
