### PR TITLE
[RD-18] feat(internal): Add visual single prob event;

### DIFF
--- a/roll-dice/internal/options/options.go
+++ b/roll-dice/internal/options/options.go
@@ -73,7 +73,16 @@ func (options Options) runOption(opt int) (bool, error) {
 	if exists {
 		for !done {
 			done, err = opt_t.process()
+
+			if err != nil {
+				// Give feedback on any errors before next prompt
+				fmt.Print(err.Error())
+			}
+
+			fmt.Print("\n\n")
 		}
+
+		fmt.Print("Returning to main menu ...\n")
 
 		done = done && opt == exit
 	}

--- a/roll-dice/internal/probgen/coinflip.go
+++ b/roll-dice/internal/probgen/coinflip.go
@@ -6,13 +6,30 @@ describes coin flips
 */
 package probgen
 
-import "fmt"
+import (
+	"fmt"
+	"strconv"
+)
 
 // Potential values
 const (
 	Heads = "Heads"
 	Tails = "Tails"
 )
+
+// All visual representations of coins
+var coinVisuals = []string{
+	" -----\n" +
+		"/     \\\n" +
+		"|  H  |\n" +
+		"\\     /\n" +
+		" -----\n",
+	" -----\n" +
+		"/     \\\n" +
+		"|  T  |\n" +
+		"\\     /\n" +
+		" -----\n",
+}
 
 type CoinFlip struct {
 	numEvents int // number of coin flips
@@ -49,6 +66,23 @@ func (coinFlip CoinFlip) execute() error {
 	return err
 }
 
+func (coinFlip CoinFlip) DisplayOneAction() {
+	pe := ProbEvent{
+		numEvents: 1,
+		outcomes: []string{
+			Heads,
+			Tails},
+		prng: randNumGen}
+
+	pev := pe.getProbValue()
+	res, err := strconv.Atoi(pev)
+	if err != nil {
+		fmt.Print(err.Error())
+	}
+
+	fmt.Print(coinVisuals[res])
+}
+
 // Print the coin flip results. Example:
 //
 // numEvents: 123435
@@ -64,6 +98,8 @@ func (coinFlip CoinFlip) display(res map[string]int) {
 		"(H) : %10f%% : %d\n(T) : %10f%% : %d\n",
 		Percent(res[Heads], coinFlip.numEvents), res[Heads],
 		Percent(res[Tails], coinFlip.numEvents), res[Tails])
+
+	fmt.Print("\n")
 }
 
 // Retrieve number of events

--- a/roll-dice/internal/probgen/diceroll.go
+++ b/roll-dice/internal/probgen/diceroll.go
@@ -13,6 +13,7 @@ import (
 )
 
 const ErrInvalidDiceType = "invalid number of dice sides: must be one of " + ValidDiceTypes
+const ErrUnsupportedDiceType = "unsupported dice type, only support D6 for now"
 
 // Potential dice types
 const (
@@ -33,6 +34,40 @@ var dicePossibleValues = []string{
 	"7", "8", "9", "10", // -> D10
 	"11", "12", // -> D12
 	"13", "14", "15", "16", "17", "18", "19", "20", // -> D20
+}
+
+// All visual representations of 6 sided dice
+var d6Visuals = []string{
+	" -------\n" +
+		"|       |\n" +
+		"|   o   |\n" +
+		"|       |\n" +
+		" -------\n",
+	" -------\n" +
+		"| o     |\n" +
+		"|       |\n" +
+		"|     o |\n" +
+		" -------\n",
+	" -------\n" +
+		"| o     |\n" +
+		"|   o   |\n" +
+		"|     o |\n" +
+		" -------\n",
+	" -------\n" +
+		"| o   o |\n" +
+		"|       |\n" +
+		"| o   o |\n" +
+		" -------\n",
+	" -------\n" +
+		"| o   o |\n" +
+		"|   o   |\n" +
+		"| o   o |\n" +
+		" -------\n",
+	" -------\n" +
+		"| o   o |\n" +
+		"| o   o |\n" +
+		"| o   o |\n" +
+		" -------\n",
 }
 
 type DiceRoll struct {
@@ -75,16 +110,43 @@ func (diceRoll DiceRoll) execute() error {
 	return err
 }
 
-// Print the coin flip results. Example:
+func DisplayOneAction(nSides int) {
+	pe := ProbEvent{
+		numEvents: 1,
+		outcomes:  possibleDiceValues(nSides),
+		prng:      randNumGen}
+
+	pev := pe.getProbValue()
+	res, err := strconv.Atoi(pev)
+	if err != nil {
+		fmt.Print(err.Error())
+	}
+
+	// Only support D6 for now
+	switch nSides {
+	case D6:
+		fmt.Print(d6Visuals[res])
+	default:
+		fmt.Print(ErrUnsupportedDiceType)
+	}
+}
+
+// Print the dice roll results. Example:
 //
-// numEvents: 123435
+// numEvents: 2
 //
-// (H) :  49.882126% : 61572
+// numSides: 4
 //
-// (T) :  50.117874% : 61863
+// [1]  :  50.00000% : 1
+//
+// [2] :   50.00000% : 1
+//
+// [3] :    0.00000% : 0
+//
+// [4] :    0.00000% : 0
 //
 //	Params
-//		res map[string]int : results of coin flips
+//		res map[string]int : results of dice rolls
 func (diceRoll DiceRoll) display(res map[string]int) {
 	for i := 1; i <= diceRoll.numSides; i++ {
 		i_s := strconv.Itoa(i)
@@ -95,6 +157,7 @@ func (diceRoll DiceRoll) display(res map[string]int) {
 			res[i_s],
 		)
 	}
+	fmt.Print("\n")
 }
 
 // Retrieve number of events

--- a/roll-dice/internal/probgen/probgen_test.go
+++ b/roll-dice/internal/probgen/probgen_test.go
@@ -251,27 +251,26 @@ func TestDiceRollValidate(t *testing.T) {
 	testing_utils.AssertEQb(t, false, ok)
 	testing_utils.AssertEQ(t, ErrInvalidDiceType, err.Error())
 
-
 	// Valid dice types (D4, D6, D10, D12, D20)
 
 	diceRoll = NewDiceRoll(3, D4)
-	ok, err = diceRoll.validate()
+	ok, _ = diceRoll.validate()
 	testing_utils.AssertEQb(t, true, ok)
 
 	diceRoll = NewDiceRoll(3, D6)
-	ok, err = diceRoll.validate()
+	ok, _ = diceRoll.validate()
 	testing_utils.AssertEQb(t, true, ok)
 
 	diceRoll = NewDiceRoll(3, D10)
-	ok, err = diceRoll.validate()
+	ok, _ = diceRoll.validate()
 	testing_utils.AssertEQb(t, true, ok)
 
 	diceRoll = NewDiceRoll(3, D12)
-	ok, err = diceRoll.validate()
+	ok, _ = diceRoll.validate()
 	testing_utils.AssertEQb(t, true, ok)
 
 	diceRoll = NewDiceRoll(3, D20)
-	ok, err = diceRoll.validate()
+	ok, _ = diceRoll.validate()
 	testing_utils.AssertEQb(t, true, ok)
 }
 
@@ -353,7 +352,7 @@ func TestGenProbDisplaysCoinFlip(t *testing.T) {
 	output := testing_utils.CaptureAndRestoreOutput(r, w, origStdout)
 	expected :=
 		"(H) : 100.000000% : 1\n" +
-			"(T) :   0.000000% : 0\n"
+			"(T) :   0.000000% : 0\n\n"
 	testing_utils.AssertEQ(t, expected, output)
 
 	// 2) Small scale should have round numbers
@@ -368,7 +367,7 @@ func TestGenProbDisplaysCoinFlip(t *testing.T) {
 	output = testing_utils.CaptureAndRestoreOutput(r, w, origStdout)
 	expected =
 		"(H) :  40.000000% : 4\n" +
-			"(T) :  60.000000% : 6\n"
+			"(T) :  60.000000% : 6\n\n"
 	testing_utils.AssertEQ(t, expected, output)
 
 	// 3) Large scale, non round should handle large values
@@ -383,7 +382,7 @@ func TestGenProbDisplaysCoinFlip(t *testing.T) {
 	output = testing_utils.CaptureAndRestoreOutput(r, w, origStdout)
 	expected =
 		"(H) :  49.975849% : 499761\n" +
-			"(T) :  50.024151% : 500244\n"
+			"(T) :  50.024151% : 500244\n\n"
 	testing_utils.AssertEQ(t, expected, output)
 }
 
@@ -411,7 +410,7 @@ func TestGenProbDisplaysDiceRoll(t *testing.T) {
 			"[3]  :   0.000000% : 0\n" +
 			"[4]  :   0.000000% : 0\n" +
 			"[5]  :   0.000000% : 0\n" +
-			"[6]  :   0.000000% : 0\n"
+			"[6]  :   0.000000% : 0\n\n"
 	testing_utils.AssertEQ(t, expected, output)
 
 	// 2) Small scale should have round numbers
@@ -446,7 +445,7 @@ func TestGenProbDisplaysDiceRoll(t *testing.T) {
 			"[9]  :   0.000000% : 0\n" +
 			"[10] :   0.000000% : 0\n" +
 			"[11] :  10.000000% : 1\n" +
-			"[12] :  10.000000% : 1\n"
+			"[12] :  10.000000% : 1\n\n"
 	testing_utils.AssertEQ(t, expected, output)
 
 	// 3) Large scale, non round should handle large values
@@ -465,6 +464,45 @@ func TestGenProbDisplaysDiceRoll(t *testing.T) {
 		"[1]  :  25.006374% : 250065\n" +
 			"[2]  :  24.982475% : 249826\n" +
 			"[3]  :  24.957375% : 249575\n" +
-			"[4]  :  25.053774% : 250539\n"
+			"[4]  :  25.053774% : 250539\n\n"
 	testing_utils.AssertEQ(t, expected, output)
+}
+
+func TestDisplayOneDiceRollUnsupported(t *testing.T) {
+	// Test the proper unsupported dice type handling for single action
+
+	// Single D4 (-)
+	origStdout, r, w := testing_utils.RedirectStdout()
+
+	DisplayOneAction(D4)
+	output := testing_utils.CaptureAndRestoreOutput(r, w, origStdout)
+	testing_utils.AssertEQb(t, false, output != ErrUnsupportedDiceType)
+
+	// Single D6 (+)
+	origStdout, r, w = testing_utils.RedirectStdout()
+
+	DisplayOneAction(D6)
+	output = testing_utils.CaptureAndRestoreOutput(r, w, origStdout)
+	testing_utils.AssertEQb(t, true, testing_utils.Contains(d6Visuals, output))
+
+	// Single D10 (-)
+	origStdout, r, w = testing_utils.RedirectStdout()
+
+	DisplayOneAction(D10)
+	output = testing_utils.CaptureAndRestoreOutput(r, w, origStdout)
+	testing_utils.AssertEQb(t, false, output != ErrUnsupportedDiceType)
+
+	// Single D12 (-)
+	origStdout, r, w = testing_utils.RedirectStdout()
+
+	DisplayOneAction(D12)
+	output = testing_utils.CaptureAndRestoreOutput(r, w, origStdout)
+	testing_utils.AssertEQb(t, false, output != ErrUnsupportedDiceType)
+
+	// Single D20 (-)
+	origStdout, r, w = testing_utils.RedirectStdout()
+
+	DisplayOneAction(D20)
+	output = testing_utils.CaptureAndRestoreOutput(r, w, origStdout)
+	testing_utils.AssertEQb(t, false, output != ErrUnsupportedDiceType)
 }

--- a/roll-dice/internal/testing_utils/testing_utils.go
+++ b/roll-dice/internal/testing_utils/testing_utils.go
@@ -141,3 +141,19 @@ func AssertNIL(t *testing.T, err error) {
 		t.Errorf(AssertFailed, file, line, "nil", err.Error())
 	}
 }
+
+// Check whether a particular item is in the slice
+//
+//	Params
+//		s []T  : slice to check for membership
+//		item T : the item to check for in s
+//	Returns
+//		bool : true if found, false otherwise
+func Contains[T comparable](s []T, item T) bool {
+	for _, v := range s {
+		if v == item {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
Provide internal function to execute a single probability event and display a visual representation for coins and dice.

Not yet exposed to users